### PR TITLE
move types.ContainerExecStartOptions to container.ExecStartOptions

### DIFF
--- a/api/server/router/container/backend.go
+++ b/api/server/router/container/backend.go
@@ -17,7 +17,7 @@ type execBackend interface {
 	ContainerExecCreate(name string, config *types.ExecConfig) (string, error)
 	ContainerExecInspect(id string) (*backend.ExecInspect, error)
 	ContainerExecResize(name string, height, width int) error
-	ContainerExecStart(ctx context.Context, name string, options types.ContainerExecStartOptions) error
+	ContainerExecStart(ctx context.Context, name string, options container.ExecStartOptions) error
 	ExecExists(name string) (bool, error)
 }
 

--- a/api/server/router/container/exec.go
+++ b/api/server/router/container/exec.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/docker/api/server/httputils"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/versions"
 	"github.com/docker/docker/errdefs"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -139,7 +140,7 @@ func (s *containerRouter) postContainerExecStart(ctx context.Context, w http.Res
 		}
 	}
 
-	options := types.ContainerExecStartOptions{
+	options := container.ExecStartOptions{
 		Stdin:       stdin,
 		Stdout:      stdout,
 		Stderr:      stderr,

--- a/api/types/client.go
+++ b/api/types/client.go
@@ -57,14 +57,6 @@ type ContainerExecInspect struct {
 	Pid         int
 }
 
-// ContainerExecStartOptions holds the options to start container's exec
-type ContainerExecStartOptions struct {
-	Stdin       io.Reader
-	Stdout      io.Writer
-	Stderr      io.Writer
-	ConsoleSize *[2]uint `json:",omitempty"`
-}
-
 // ContainerListOptions holds parameters to list containers with.
 type ContainerListOptions struct {
 	Size    bool

--- a/api/types/container/config.go
+++ b/api/types/container/config.go
@@ -1,6 +1,7 @@
 package container // import "github.com/docker/docker/api/types/container"
 
 import (
+	"io"
 	"time"
 
 	"github.com/docker/docker/api/types/strslice"
@@ -50,6 +51,14 @@ type HealthConfig struct {
 	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
 	// Zero means inherit.
 	Retries int `json:",omitempty"`
+}
+
+// ExecStartOptions holds the options to start container's exec.
+type ExecStartOptions struct {
+	Stdin       io.Reader
+	Stdout      io.Writer
+	Stderr      io.Writer
+	ConsoleSize *[2]uint `json:",omitempty"`
 }
 
 // Config contains the configuration data about a container.

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/container/stream"
@@ -151,7 +152,7 @@ func (daemon *Daemon) ContainerExecCreate(name string, config *types.ExecConfig)
 // ContainerExecStart starts a previously set up exec instance. The
 // std streams are set up.
 // If ctx is cancelled, the process is terminated.
-func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, options types.ContainerExecStartOptions) (err error) {
+func (daemon *Daemon) ContainerExecStart(ctx context.Context, name string, options containertypes.ExecStartOptions) (err error) {
 	var (
 		cStdin           io.ReadCloser
 		cStdout, cStderr io.Writer

--- a/daemon/health.go
+++ b/daemon/health.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/strslice"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/daemon/exec"
@@ -98,7 +99,7 @@ func (p *cmdProbe) run(ctx context.Context, d *Daemon, cntr *container.Container
 	defer cancelProbe()
 	execErr := make(chan error, 1)
 
-	options := types.ContainerExecStartOptions{
+	options := containertypes.ExecStartOptions{
 		Stdout: output,
 		Stderr: output,
 	}


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/43622#discussion_r898993618
