### PR TITLE
Add back API-version gate for image-create events

### DIFF
--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -273,7 +273,18 @@ func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *
 	buffered, l := s.backend.SubscribeToEvents(since, until, ef)
 	defer s.backend.UnsubscribeFromEvents(l)
 
+	shouldSkip := func(ev events.Message) bool { return false }
+	if versions.LessThan(httputils.VersionFromContext(ctx), "1.46") {
+		// Image create events were added in API 1.46
+		shouldSkip = func(ev events.Message) bool {
+			return ev.Type == "image" && ev.Action == "create"
+		}
+	}
+
 	for _, ev := range buffered {
+		if shouldSkip(ev) {
+			continue
+		}
 		if err := enc.Encode(ev); err != nil {
 			return err
 		}
@@ -289,6 +300,9 @@ func (s *systemRouter) getEvents(ctx context.Context, w http.ResponseWriter, r *
 			jev, ok := ev.(events.Message)
 			if !ok {
 				log.G(ctx).Warnf("unexpected event message: %q", ev)
+				continue
+			}
+			if shouldSkip(jev) {
 				continue
 			}
 			if err := enc.Encode(jev); err != nil {

--- a/integration-cli/cli/cli.go
+++ b/integration-cli/cli/cli.go
@@ -3,6 +3,7 @@ package cli // import "github.com/docker/docker/integration-cli/cli"
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -161,7 +162,10 @@ func WithTimeout(timeout time.Duration) func(cmd *icmd.Cmd) func() {
 // WithEnvironmentVariables sets the specified environment variables for the command to run
 func WithEnvironmentVariables(envs ...string) func(cmd *icmd.Cmd) func() {
 	return func(cmd *icmd.Cmd) func() {
-		cmd.Env = envs
+		if cmd.Env == nil {
+			cmd.Env = os.Environ()
+		}
+		cmd.Env = append(cmd.Env, envs...)
 		return nil
 	}
 }

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -6215,10 +6215,14 @@ func (s *DockerCLIBuildSuite) TestBuildEmitsImageCreateEvent(t *testing.T) {
 			t.Log(b.Stdout())
 			t.Log(b.Stderr())
 
-			cmd := cli.Docker(cli.Args("events",
-				"--filter", "action=create,type=image",
-				"--since", before.Format(time.RFC3339),
-			), cli.WithTimeout(time.Millisecond*300))
+			cmd := cli.Docker(
+				cli.Args("events",
+					"--filter", "action=create,type=image",
+					"--since", before.Format(time.RFC3339),
+				),
+				cli.WithTimeout(time.Millisecond*300),
+				cli.WithEnvironmentVariables("DOCKER_API_VERSION=v1.46"), // FIXME(thaJeztah): integration-cli runs docker CLI 17.06; we're "upgrading" the API version to a version it doesn't support here ;)
+			)
 
 			t.Log(cmd.Stdout())
 


### PR DESCRIPTION
- for https://github.com/moby/moby/pull/47929

Could use a claner option, and probably we should move the test to "integration/", but this works for now, because the events API didn't change since 17.06, and we just specify a newer version of the API (which, technicaly, the 17.06 CLI doesn't support, but DOCKER_API_VERSION allows any version to be set).

